### PR TITLE
remove font-weight: bold

### DIFF
--- a/app/kata-page/KataPageStyleSheet.tsx
+++ b/app/kata-page/KataPageStyleSheet.tsx
@@ -8,7 +8,6 @@ export const styles = StyleSheet.create({
   },
   titleText: {
     fontSize: 20,
-    fontWeight: "bold",
     textAlign: "center",
     padding: 10,
     marginTop: "3%",


### PR DESCRIPTION
font-weight: bold was stopping the application of Dogica to kata title text.